### PR TITLE
Removing overrides

### DIFF
--- a/backend/ml/baseline_models.py
+++ b/backend/ml/baseline_models.py
@@ -2,7 +2,6 @@ import os
 from dataclasses import dataclass
 import pickle
 import numpy as np
-from overrides import overrides
 import torch
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
@@ -53,12 +52,10 @@ class BoWCosine(Detector):
         self.tfidf_vectorizer = TfidfVectorizer ()
         self.tfidf_vectorizer.fit(corpus)
         
-    @overrides
     def _encode(self, sentences):
         vectors = self.tfidf_vectorizer.transform(sentences)
         return vectors
 
-    @overrides
     def _score(self,
                encoded_sentences,
                encoded_misconceptions) -> np.ndarray:
@@ -80,7 +77,6 @@ class GloVeCosine(Detector):
                 vector = np.asarray(values[1:], "float32")
                 self.embeddings_dict[word] = vector
         
-    @overrides
     def _encode(self, sentences):
         enc_sentences = []
         for s in sentences:
@@ -88,7 +84,6 @@ class GloVeCosine(Detector):
         
         return enc_sentences
 
-    @overrides
     def _score(self,
                encoded_sentences,
                encoded_misconceptions) -> np.ndarray:
@@ -114,7 +109,6 @@ class BERTCosine(Detector):
             self.tokenizer = AutoTokenizer.from_pretrained('digitalepidemiologylab/covid-twitter-bert')
             self.model = AutoModel.from_pretrained('digitalepidemiologylab/covid-twitter-bert')
         
-    @overrides
     def _encode(self, sentences):
         results = []
         with torch.no_grad():
@@ -127,7 +121,6 @@ class BERTCosine(Detector):
                 results.append (avg_embeddings)
             return results
     
-    #@overrides
     #def _encode(self, sentences):
      #   with torch.no_grad():
       #          model_input = self.tokenizer.batch_encode_plus(sentences, pad_to_max_length=True, return_attention_mask=True, return_tensors='pt' )
@@ -137,7 +130,6 @@ class BERTCosine(Detector):
           #      avg_embeddings = embeddings.mean(axis=1).tolist()
         #return avg_embeddings 
     
-    @overrides
     def _score(self,
                encoded_sentences,
                encoded_misconceptions) -> np.ndarray:
@@ -162,14 +154,12 @@ class BoWLogistic(Detector):
         path = os.path.join('/',model_dir, 'bow_log.pkl')
         self.logreg = pickle.load(open(path, "rb"))
         
-    @overrides
     def _encode(self, sentences, sent_type):
         if sent_type == 'prem':
             return self.prem_vectorizer.transform(sentences)
         elif sent_type == 'hyp':
             return self.hyp_vectorizer.transform(sentences)
         
-    @overrides
     def _predict(self,
                encoded_premise,
                encoded_hypothesis) -> np.ndarray:
@@ -198,14 +188,12 @@ class BoELogistic(Detector):
         path = os.path.join('/',model_dir, 'boe_log.pkl') 
         self.logreg = pickle.load(open(path, "rb"))
         
-    @overrides
     def _encode(self, sentences):
         enc_sentences = []
         for s in sentences:
                 enc_sentences.append ( glove_word_average(self.embeddings_dict, s) )
         return enc_sentences
         
-    @overrides
     def _predict(self,
                encoded_premise,
                encoded_hypothesis) -> np.ndarray:

--- a/backend/ml/bertscore.py
+++ b/backend/ml/bertscore.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import List
 
 import numpy as np
-from overrides import overrides
 import torch
 from transformers import AutoModel, AutoTokenizer
 
@@ -124,7 +123,6 @@ class BertScoreDetector(Detector, torch.nn.Module):
         self._tokenizer = AutoTokenizer.from_pretrained(model_name)
         self._model = AutoModel.from_pretrained(model_name)
 
-    @overrides
     def _encode(self, sentences: List[str]) -> MaskedEmbeddings:
         device = next(self.parameters()).device
         model_input = self._tokenizer.batch_encode_plus(
@@ -138,16 +136,14 @@ class BertScoreDetector(Detector, torch.nn.Module):
         embeddings, *_ = self._model(**model_input)
         return MaskedEmbeddings(embeddings, mask)
 
-    @overrides
     def _score(self,
-               encoded_sentences: MaskedEmbeddings,
-               encoded_misconceptions: MaskedEmbeddings) -> np.ndarray:
+               sentences: MaskedEmbeddings,
+               misconceptions: MaskedEmbeddings) -> np.ndarray:
         with torch.no_grad():
-            score_dict = bertscore(encoded_sentences, encoded_misconceptions)
+            score_dict = bertscore(sentences, misconceptions)
         score = score_dict[self._score_type]
         return score.cpu().numpy()
 
-    @overrides
     def _predict(self, scores: np.ndarray) -> List[List[int]]:
         # TODO: @rloganiv - Something smarter thank just returning top-5.
         k = 5

--- a/backend/ml/bi_lstm.py
+++ b/backend/ml/bi_lstm.py
@@ -64,7 +64,6 @@ class BiLSTM(nn.Module):
                
         return prediction
 
-    #@overrides
     def _encode (self, sentences):
 
       ## Tokenize

--- a/backend/ml/misconception.py
+++ b/backend/ml/misconception.py
@@ -10,6 +10,7 @@ from typing import Tuple
 from backend.stream.db.operation import get_misinfo
 from backend.stream.db.util import get_engine
 
+
 def _tuplify(x):
     """Converts lists to tuples."""
     if isinstance(x, list):

--- a/backend/ml/pipeline.py
+++ b/backend/ml/pipeline.py
@@ -17,7 +17,7 @@ class Pipeline:
     def __call__(self, sentences, misconceptions):
         # Step 1. Retrieve most relevant misconception.
         predictions = self._retriever.predict(sentences, misconceptions)
-        logger.info('Retrieval output: %s', predictions)
+        logger.debug('Retrieval output: %s', predictions)
 
         # Step 2. Perform stance detection.
         # TODO: Support multiple relevant misconceptions.
@@ -41,7 +41,7 @@ class Pipeline:
             label = 'agrees' if label_id == 0 else 'disagrees'
             output_dict['predictions'].append({
                 'label': label,
-                'misinformation': misconception
+                'misinformation': misconception,
             })
         return output_dict
 

--- a/backend/stream/db/table.py
+++ b/backend/stream/db/table.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, JSON, String
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
 
 base_cls = declarative_base()
 TABLE_CLASS_DICT = dict()
@@ -106,6 +107,11 @@ class Output(base_cls):
     confidence = Column(Float, nullable=False)
     misc = Column(JSON, nullable=True)
     date = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    input = relationship('Input', single_parent=True)
+    model = relationship('Model')
+    misinformation = relationship('Misinformation')
+    label = relationship('Label')
 
     @classmethod
     def check_if_exists(cls, entity, session):

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,3 @@ google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
 
-# Other
-overrides>=2.8.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
         'google-auth-httplib2',
         'google-auth-oauthlib',
         'gunicorn>=20.0.4',
-        'overrides>=2.8.0',
         'transformers[torch]==2.7.0',  # TODO: Upgrade to version 3.
         'sqlalchemy>=1.3.16'
     ],


### PR DESCRIPTION
Fixes #61. Just going to remove overrides annotations since they are too strict. `torch.nn.Module.forward` can have a lot of different return types.